### PR TITLE
Fix _parse_pages_basic and add tests

### DIFF
--- a/pdf_signer.py
+++ b/pdf_signer.py
@@ -209,37 +209,34 @@ def _has_advanced_features(kwargs):
 
 def _parse_pages_basic(pages_spec, total_pages):
     """Analisi base delle pagine senza il modulo avanzato."""
+    pages = []
+
     if pages_spec == 'first':
-        return [0] if total_pages > 0 else []
+        if total_pages > 0:
+            pages.append(0)
     elif pages_spec == 'last':
-        return [total_pages - 1] if total_pages > 0 else []
+        if total_pages > 0:
+            pages.append(total_pages - 1)
     elif pages_spec.isdigit():
         page_num = int(pages_spec) - 1
-        return [page_num] if 0 <= page_num < total_pages else []
+        if 0 <= page_num < total_pages:
+            pages.append(page_num)
     else:
         # Gestione base di range separati da virgole
-        pages = []
         for part in pages_spec.split(','):
             part = part.strip()
             if '-' in part:
                 try:
                     start, end = map(int, part.split('-'))
-                    pages.extend(range(start-1, min(end, total_pages)))
-                except:
+                    pages.extend(range(start - 1, min(end, total_pages)))
+                except ValueError:
                     continue
             elif part.isdigit():
                 page_num = int(part) - 1
                 if 0 <= page_num < total_pages:
                     pages.append(page_num)
-        return sorted(list(set(pages)))
-        pages = []
-        for part in pages_spec.split(','):
-            part = part.strip()
-            if part.isdigit():
-                page_num = int(part) - 1
-                if 0 <= page_num < total_pages:
-                    pages.append(page_num)
-        return pages
+
+    return sorted(list(set(pages)))
 
 
 def interactive_mode():

--- a/tests/test_parse_pages_basic.py
+++ b/tests/test_parse_pages_basic.py
@@ -1,0 +1,22 @@
+import unittest
+from pdf_signer import _parse_pages_basic
+
+class TestParsePagesBasic(unittest.TestCase):
+    def test_single_numbers(self):
+        self.assertEqual(_parse_pages_basic('1', 10), [0])
+        self.assertEqual(_parse_pages_basic('3', 10), [2])
+
+    def test_range(self):
+        self.assertEqual(_parse_pages_basic('1-3', 10), [0, 1, 2])
+        self.assertEqual(_parse_pages_basic('8-15', 10), [7, 8, 9])
+
+    def test_mix_and_duplicates(self):
+        self.assertEqual(_parse_pages_basic('1,1,2-3,2', 10), [0, 1, 2])
+        self.assertEqual(_parse_pages_basic('3-5,2,4', 10), [1, 2, 3, 4])
+
+    def test_first_last(self):
+        self.assertEqual(_parse_pages_basic('first', 10), [0])
+        self.assertEqual(_parse_pages_basic('last', 10), [9])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- remove unreachable code from `_parse_pages_basic`
- ensure `_parse_pages_basic` always returns an ordered list without duplicates
- add unit tests for various page specifications

## Testing
- `python -m unittest tests/test_parse_pages_basic.py`

------
https://chatgpt.com/codex/tasks/task_e_68509d41b37c832aba4d3489a95ad381