### PR TITLE
Fix _parse_pages_basic and add tests

### DIFF
--- a/pdf_signer.py
+++ b/pdf_signer.py
@@ -232,14 +232,6 @@ def _parse_pages_basic(pages_spec, total_pages):
                 if 0 <= page_num < total_pages:
                     pages.append(page_num)
         return sorted(list(set(pages)))
-        pages = []
-        for part in pages_spec.split(','):
-            part = part.strip()
-            if part.isdigit():
-                page_num = int(part) - 1
-                if 0 <= page_num < total_pages:
-                    pages.append(page_num)
-        return pages
 
 
 def interactive_mode():

--- a/tests/test_parse_pages_basic.py
+++ b/tests/test_parse_pages_basic.py
@@ -1,0 +1,38 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from pdf_signer import _parse_pages_basic
+
+
+def test_first_page():
+    assert _parse_pages_basic('first', 5) == [0]
+
+
+def test_last_page():
+    assert _parse_pages_basic('last', 5) == [4]
+
+
+def test_single_page():
+    assert _parse_pages_basic('3', 5) == [2]
+
+
+def test_comma_separated_list():
+    assert _parse_pages_basic('1,3,5', 5) == [0, 2, 4]
+
+
+def test_range():
+    assert _parse_pages_basic('2-4', 5) == [1, 2, 3]
+
+
+def test_mixed_spec():
+    assert _parse_pages_basic('1,3-5', 5) == [0, 2, 3, 4]
+
+
+def test_range_exceeds_total_pages():
+    assert _parse_pages_basic('2-10', 5) == [1, 2, 3, 4]
+
+
+def test_invalid_spec_returns_empty():
+    assert _parse_pages_basic('invalid', 5) == []


### PR DESCRIPTION
## Summary
- remove leftover code from `_parse_pages_basic`
- add unit tests for `_parse_pages_basic`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68509d7cb9f0832a991bb55b48cb17bf