### PR TITLE
Improve email template formatting

### DIFF
--- a/email_template_example.yaml
+++ b/email_template_example.yaml
@@ -1,7 +1,7 @@
 # Template Email per PDF Signer
 # Personalizza oggetto e corpo dell'email
 
-subject: "Documento PDF Firmato - {{filename}}"
+subject: "Documento PDF Firmato - {filename}"
 
 body: |
   Gentile destinatario,
@@ -9,14 +9,14 @@ body: |
   In allegato troverai il documento PDF firmato digitalmente.
   
   Dettagli della firma:
-  - Data e ora: {{timestamp}}
-  - Documento: {{filename}}
-  - Pagine firmate: {{pages_signed}}
+  - Data e ora: {timestamp}
+  - Documento: {filename}
+  - Pagine firmate: {pages_signed}
   
   Questo documento è stato elaborato automaticamente dal sistema PDF Signer.
   
   Cordiali saluti,
-  {{author}}
+  {author}
 
 # Allegati aggiuntivi (opzionale)
 additional_attachments:
@@ -24,9 +24,9 @@ additional_attachments:
   - path/to/instructions.txt
 
 # Variabili disponibili nel template:
-# {{filename}} - Nome del file PDF
-# {{timestamp}} - Data e ora corrente
-# {{pages_signed}} - Elenco delle pagine firmate
-# {{author}} - Autore specificato nei metadati
-# {{title}} - Titolo del documento
-# {{subject}} - Oggetto del documento
+# {filename} - Nome del file PDF
+# {timestamp} - Data e ora corrente
+# {pages_signed} - Elenco delle pagine firmate
+# {author} - Autore specificato nei metadati
+# {title} - Titolo del documento
+# {subject} - Oggetto del documento

--- a/tests/test_email_template.py
+++ b/tests/test_email_template.py
@@ -1,0 +1,44 @@
+import os
+import sys
+import smtplib
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from pdf_signer import send_email_with_pdf
+
+class DummySMTP:
+    def __init__(self, server, port):
+        self.sent_message = None
+    def starttls(self):
+        pass
+    def login(self, user, pwd):
+        pass
+    def send_message(self, msg):
+        self.sent_message = msg
+    def quit(self):
+        pass
+
+
+def test_placeholder_substitution(tmp_path, monkeypatch):
+    pdf = tmp_path / "doc.pdf"
+    pdf.write_text("dummy")
+    template = tmp_path / "tmpl.txt"
+    template.write_text("Hello {filename} - {timestamp}")
+
+    smtp_instance = DummySMTP("", 0)
+    monkeypatch.setattr(smtplib, "SMTP", lambda *args, **kwargs: smtp_instance)
+
+    config = {
+        "server": "localhost",
+        "port": 25,
+        "username": "",
+        "password": "",
+        "use_tls": False,
+    }
+
+    send_email_with_pdf(str(pdf), config, ["dest@example.com"], template_path=str(template))
+
+    assert smtp_instance.sent_message is not None
+    body_part = smtp_instance.sent_message.get_payload()[0]
+    body = body_part.get_payload(decode=True).decode("utf-8")
+    assert "doc.pdf" in body
+    assert "{filename}" not in body


### PR DESCRIPTION
## Summary
- update `email_template_example.yaml` to use Python format placeholders
- enhance `send_email_with_pdf` to format subject and body and handle YAML templates
- add test checking placeholder substitution in email body

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68509d835e48832aa209a66edbdf08be