### PR TITLE
Add note about storing credentials

### DIFF
--- a/email_config_example.yaml
+++ b/email_config_example.yaml
@@ -1,6 +1,9 @@
 # Configurazione Email per PDF Signer
 # Copia questo file e rinominalo in email_config.yaml
 # Inserisci le tue credenziali SMTP
+# ATTENZIONE: non salvare qui password reali se il repository viene condiviso
+# È consigliabile usare variabili d'ambiente (es. SMTP_PASS) o un file di
+# configurazione fuori dal repository
 
 smtp_server: smtp.gmail.com
 smtp_port: 587


### PR DESCRIPTION
## Summary
- warn about storing real passwords in `email_config_example.yaml`
- recommend env vars or an external file for credentials

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68509d9095ac832ab50e3c5be0ffc2ca