### PR TITLE
Optimize preview reload and benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ last_watermark_path: '~/signatures/official.png'
 window_geometry: '1200x800'
 preview_quality: 'high'  # high, medium, low
 theme: 'default'
+benchmark_preview: false  # stampa il tempo di aggiornamento anteprima
 
 # Advanced defaults
 default_pages: 'all'

--- a/config_example.yaml
+++ b/config_example.yaml
@@ -8,6 +8,7 @@ default_position: 'bottom-right'
 default_opacity: 0.8
 window_geometry: '1200x800'
 preview_quality: 'medium'
+benchmark_preview: false
 
 # Altre impostazioni disponibili:
 # auto_update_preview: true

--- a/pdf_signer_gui.py
+++ b/pdf_signer_gui.py
@@ -20,6 +20,7 @@ import tempfile
 import fitz  # PyMuPDF per anteprima PDF
 import subprocess
 import sys
+import time
 
 # Import delle funzioni dal modulo originale
 from pdf_signer import add_watermark_to_pdf, create_watermark_pdf, calculate_watermark_size_points
@@ -48,7 +49,8 @@ class ConfigManager:
             'default_position': 'bottom-right',
             'default_opacity': 0.8,
             'window_geometry': '1200x800',
-            'preview_quality': 'medium'
+            'preview_quality': 'medium',
+            'benchmark_preview': False
         }
         
         try:
@@ -203,6 +205,7 @@ class PDFPreviewCanvas(tk.Canvas):
         super().__init__(parent, bg='white', relief='sunken', bd=2)
         self.preview_callback = preview_callback
         self.pdf_doc = None
+        self.pdf_path = None
         self.current_page = 0
         self.page_image = None
         self.watermark_image = None
@@ -218,10 +221,12 @@ class PDFPreviewCanvas(tk.Canvas):
         self.bind("<Configure>", self.on_resize)
     
     def load_pdf(self, pdf_path):
-        """Carica un PDF per l'anteprima."""
+        """Carica un PDF per l'anteprima, evitando riaperture inutili."""
         try:
-            self.pdf_doc = fitz.open(pdf_path)
-            self.current_page = 0
+            if self.pdf_doc is None or self.pdf_path != pdf_path:
+                self.pdf_doc = fitz.open(pdf_path)
+                self.pdf_path = pdf_path
+                self.current_page = 0
             self.render_page()
             return True
         except Exception as e:
@@ -1223,10 +1228,13 @@ class PDFSignerGUI:
         if not self.pdf_path.get() or not os.path.exists(self.pdf_path.get()):
             self.status_var.set("Seleziona un PDF valido")
             return
-        
+
+        benchmark = self.config_manager.config.get('benchmark_preview', False)
+        start_time = time.perf_counter() if benchmark else None
+
         self.status_var.set("Caricamento anteprima...")
-        
-        # Carica PDF
+
+        # Carica PDF (verrà riaperto solo se il percorso cambia)
         if self.preview_canvas.load_pdf(self.pdf_path.get()):
             # Imposta watermark
             if self.watermark_path.get() and os.path.exists(self.watermark_path.get()):
@@ -1247,6 +1255,10 @@ class PDFSignerGUI:
                 self.page_label.config(text=f"Pagina: {current_page}/{total_pages}")
         
         self.update_watermark_preview()
+
+        if benchmark and start_time is not None:
+            elapsed = time.perf_counter() - start_time
+            print(f"Tempo aggiornamento anteprima: {elapsed:.4f}s")
     
     def update_watermark_preview(self):
         """Aggiorna l'anteprima del watermark nei controlli."""


### PR DESCRIPTION
## Summary
- add optional `benchmark_preview` flag to config
- skip reopening the PDF in preview load
- print benchmark time when enabled
- document new feature

## Testing
- `python -m py_compile pdf_signer_gui.py pdf_signer.py`

------
https://chatgpt.com/codex/tasks/task_e_68509d99126c832a9054e6e187df4d86