### PR TITLE
Fix CLI parse comment line

### DIFF
--- a/pdf_signer.py
+++ b/pdf_signer.py
@@ -641,8 +641,6 @@ Formati immagine supportati: PNG, JPG, JPEG, GIF (SVG con modulo avanzato)
         args.output = str(input_path.parent / output_name)
     
     try:
-        # Prepara parametri avanzati    try:
-        # Prepara parametri avanzati
         kwargs = {}
         
         # Pagine


### PR DESCRIPTION
## Summary
- clean up duplicate comment in `command_line_mode`

## Testing
- `python -m py_compile pdf_signer.py`
- manual CLI help test via `pdf_signer.main()`

------
https://chatgpt.com/codex/tasks/task_e_68509dadddc4832ab58c13b4c6a70e87