### PR TITLE
Add center option for timestamp position

### DIFF
--- a/pdf_signer.py
+++ b/pdf_signer.py
@@ -1312,9 +1312,15 @@ def _get_timestamp_position(signature_position: str, timestamp_relative: str) ->
         },
         "top-left": {
             "below": "bottom-left",
-            "above": "top-left", 
+            "above": "top-left",
             "left": "top-left",
             "right": "top-right"
+        },
+        "center": {
+            "below": "bottom-right",
+            "above": "top-right",
+            "left": "bottom-left",
+            "right": "bottom-right"
         }
     }
     

--- a/tests/test_timestamp.py
+++ b/tests/test_timestamp.py
@@ -1,0 +1,16 @@
+import os
+import sys
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from pdf_signer import _get_timestamp_position
+
+@pytest.mark.parametrize("relative,expected", [
+    ("below", "bottom-right"),
+    ("above", "top-right"),
+    ("left", "bottom-left"),
+    ("right", "bottom-right"),
+])
+def test_center_position(relative, expected):
+    assert _get_timestamp_position("center", relative) == expected
+


### PR DESCRIPTION
## Summary
- support `center` key in `_get_timestamp_position`
- add unit tests for center timestamp logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68509dd26284832a88f5bcc34334bffa